### PR TITLE
Fix NVIDIA GPU Access in Pyxis Container-in-Container Scenarios

### DIFF
--- a/schedmd/slurm/24.11/rockylinux9/Dockerfile.pyxis
+++ b/schedmd/slurm/24.11/rockylinux9/Dockerfile.pyxis
@@ -82,6 +82,13 @@ mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
 EOR
 
+# Add NVIDIA proc mount fix for GPU compute nodes
+RUN <<EOR
+# Prepend proc mount fix to existing entrypoint
+set -xeuo pipefail
+sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
+EOR
+
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/bash_completion /usr/share/bash-completion/completions/enroot
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/hooks/extra/50-mig-config.sh /etc/enroot/hooks.d/50-mig-config.sh
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/hooks/extra/50-sharp.sh /etc/enroot/hooks.d/50-sharp.sh
@@ -134,6 +141,13 @@ mkdir -m 777 -p /usr/share/enroot/enroot-data/
 mkdir -m 755 -p /run/enroot/
 mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
+EOR
+
+# Add NVIDIA proc mount fix for GPU compute nodes
+RUN <<EOR
+# Prepend proc mount fix to existing entrypoint
+set -xeuo pipefail
+sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
 EOR
 
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/bash_completion /usr/share/bash-completion/completions/enroot

--- a/schedmd/slurm/24.11/ubuntu24.04/Dockerfile.pyxis
+++ b/schedmd/slurm/24.11/ubuntu24.04/Dockerfile.pyxis
@@ -82,6 +82,13 @@ mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
 EOR
 
+# Add NVIDIA proc mount fix for GPU compute nodes
+RUN <<EOR
+# Prepend proc mount fix to existing entrypoint
+set -xeuo pipefail
+sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
+EOR
+
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/bash_completion /usr/share/bash-completion/completions/enroot
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/hooks/extra/50-mig-config.sh /etc/enroot/hooks.d/50-mig-config.sh
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/hooks/extra/50-sharp.sh /etc/enroot/hooks.d/50-sharp.sh
@@ -139,6 +146,13 @@ mkdir -m 777 -p /usr/share/enroot/enroot-data/
 mkdir -m 755 -p /run/enroot/
 mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
+EOR
+
+# Add NVIDIA proc mount fix for GPU compute nodes
+RUN <<EOR
+# Prepend proc mount fix to existing entrypoint
+set -xeuo pipefail
+sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
 EOR
 
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/bash_completion /usr/share/bash-completion/completions/enroot

--- a/schedmd/slurm/25.05/rockylinux9/Dockerfile.pyxis
+++ b/schedmd/slurm/25.05/rockylinux9/Dockerfile.pyxis
@@ -82,6 +82,13 @@ mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
 EOR
 
+# Add NVIDIA proc mount fix for GPU compute nodes
+RUN <<EOR
+# Prepend proc mount fix to existing entrypoint
+set -xeuo pipefail
+sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
+EOR
+
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/bash_completion /usr/share/bash-completion/completions/enroot
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/hooks/extra/50-mig-config.sh /etc/enroot/hooks.d/50-mig-config.sh
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/hooks/extra/50-sharp.sh /etc/enroot/hooks.d/50-sharp.sh
@@ -134,6 +141,13 @@ mkdir -m 777 -p /usr/share/enroot/enroot-data/
 mkdir -m 755 -p /run/enroot/
 mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
+EOR
+
+# Add NVIDIA proc mount fix for GPU compute nodes
+RUN <<EOR
+# Prepend proc mount fix to existing entrypoint
+set -xeuo pipefail
+sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
 EOR
 
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/bash_completion /usr/share/bash-completion/completions/enroot

--- a/schedmd/slurm/25.05/ubuntu24.04/Dockerfile.pyxis
+++ b/schedmd/slurm/25.05/ubuntu24.04/Dockerfile.pyxis
@@ -82,6 +82,13 @@ mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
 EOR
 
+# Add NVIDIA proc mount fix for GPU compute nodes
+RUN <<EOR
+# Prepend proc mount fix to existing entrypoint
+set -xeuo pipefail
+sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
+EOR
+
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/bash_completion /usr/share/bash-completion/completions/enroot
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/hooks/extra/50-mig-config.sh /etc/enroot/hooks.d/50-mig-config.sh
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/hooks/extra/50-sharp.sh /etc/enroot/hooks.d/50-sharp.sh
@@ -139,6 +146,13 @@ mkdir -m 777 -p /usr/share/enroot/enroot-data/
 mkdir -m 755 -p /run/enroot/
 mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
+EOR
+
+# Add NVIDIA proc mount fix for GPU compute nodes
+RUN <<EOR
+# Prepend proc mount fix to existing entrypoint
+set -xeuo pipefail
+sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
 EOR
 
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/bash_completion /usr/share/bash-completion/completions/enroot

--- a/schedmd/slurm/master/rockylinux9/Dockerfile.pyxis
+++ b/schedmd/slurm/master/rockylinux9/Dockerfile.pyxis
@@ -80,6 +80,13 @@ mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
 EOR
 
+# Add NVIDIA proc mount fix for GPU compute nodes
+RUN <<EOR
+# Prepend proc mount fix to existing entrypoint
+set -xeuo pipefail
+sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
+EOR
+
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/bash_completion /usr/share/bash-completion/completions/enroot
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/hooks/extra/50-mig-config.sh /etc/enroot/hooks.d/50-mig-config.sh
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/hooks/extra/50-sharp.sh /etc/enroot/hooks.d/50-sharp.sh
@@ -132,6 +139,13 @@ mkdir -m 777 -p /usr/share/enroot/enroot-data/
 mkdir -m 755 -p /run/enroot/
 mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
+EOR
+
+# Add NVIDIA proc mount fix for GPU compute nodes
+RUN <<EOR
+# Prepend proc mount fix to existing entrypoint
+set -xeuo pipefail
+sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
 EOR
 
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/bash_completion /usr/share/bash-completion/completions/enroot

--- a/schedmd/slurm/master/ubuntu24.04/Dockerfile.pyxis
+++ b/schedmd/slurm/master/ubuntu24.04/Dockerfile.pyxis
@@ -82,6 +82,13 @@ mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
 EOR
 
+# Add NVIDIA proc mount fix for GPU compute nodes
+RUN <<EOR
+# Prepend proc mount fix to existing entrypoint
+set -xeuo pipefail
+sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
+EOR
+
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/bash_completion /usr/share/bash-completion/completions/enroot
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/hooks/extra/50-mig-config.sh /etc/enroot/hooks.d/50-mig-config.sh
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/hooks/extra/50-sharp.sh /etc/enroot/hooks.d/50-sharp.sh
@@ -139,6 +146,13 @@ mkdir -m 777 -p /usr/share/enroot/enroot-data/
 mkdir -m 755 -p /run/enroot/
 mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
+EOR
+
+# Add NVIDIA proc mount fix for GPU compute nodes
+RUN <<EOR
+# Prepend proc mount fix to existing entrypoint
+set -xeuo pipefail
+sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
 EOR
 
 ADD https://raw.githubusercontent.com/NVIDIA/enroot/refs/tags/v${ENROOT_VERSION}/conf/bash_completion /usr/share/bash-completion/completions/enroot


### PR DESCRIPTION
### Problem

GPU compute nodes were failing to start containerized workloads with the following error:

```
[2025-07-18T15:06:29.684] error: pyxis: container start failed with error code: 1
[2025-07-18T15:06:29.684] error: pyxis: printing enroot log file:
[2025-07-18T15:06:29.684] error: pyxis:     nvidia-container-cli: ldcache error: process /usr/sbin/ldconfig.
real failed with error code: 1
[2025-07-18T15:06:29.684] error: pyxis:     [ERROR] /etc/enroot/hooks.d/98-nvidia.sh exited with return code
 1
[2025-07-18T15:06:29.684] error: pyxis: couldn't start container
[2025-07-18T15:06:29.684] error: spank: required plugin spank_pyxis.so: task_init() failed with rc=-1
[2025-07-18T15:06:29.684] error: Failed to invoke spank plugin stack
srun: error: gpu-1-0: task 0: Exited with exit code 1
command terminated with exit code 1
```

This can be reproduced by running commands like:

```
srun --container-image=/tmp/nvidia+pytorch+25.04-py3.sqsh \
     --partition=gpu-1 \
     --mpi=pmi2 \
     --export=ALL \
     --gres=gpu:4 \
     --mpi=pmi2 \
     python3 -c "import torch; print('CUDA available:', torch.cuda.is_available()); print('Device count:', torch.cuda.device_count()); print('Device 0:', torch.cuda.get_device_name(0))"
```

This prevented GPU resource allocation.

### Root Cause Analysis

The issue occurs in **container-in-container scenarios** where Pyxis runs GPU containers within Slurm containers:

1. **nvidia-container-cli** needs to execute `ldconfig` to configure GPU libraries
2. In nested container environments, it uses **memory file descriptors (memfd)** for binary execution
3. The process flow:
   - nvidia-container-cli creates memfd in parent `/procfs` (before chroot)
   - Uses `fexecve(fd, ...)` instead of `execve("/path", ...)` to execute ldconfig
   - **Problem**: No procfs availability = no memfd access = ldconfig failure
4. **Permission issue**: nvidia-container-cli from the first container lacks privileges to mount procfs in the parent container

### Solution

Add early `procfs` mounting to all pyxis entrypoint scripts:

```bash
# Add NVIDIA proc mount fix for GPU compute nodes
RUN <<EOR
# Prepend proc mount fix to existing entrypoint
set -xeuo pipefail
sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
EOR
```

### Test & Verify

**Environment:** NVIDIA H100 80GB HBM3 GPUs (4x)

**Before fix:**
```bash
srun --container-image=/tmp/nvidia+pytorch+25.04-py3.sqsh --gres=gpu:4 \
  python3 -c "import torch; print('CUDA available:', torch.cuda.is_available()); print('Device count:', torch.cuda.device_count()); print('Device 0:', torch.cuda.get_device_name(0))"

...
[2025-07-18T15:06:29.684] error: pyxis: container start failed with error code: 1
[2025-07-18T15:06:29.684] error: pyxis: printing enroot log file:
[2025-07-18T15:06:29.684] error: pyxis:     nvidia-container-cli: ldcache error: process /usr/sbin/ldconfig.
real failed with error code: 1
[2025-07-18T15:06:29.684] error: pyxis:     [ERROR] /etc/enroot/hooks.d/98-nvidia.sh exited with return code
 1
[2025-07-18T15:06:29.684] error: pyxis: couldn't start container
[2025-07-18T15:06:29.684] error: spank: required plugin spank_pyxis.so: task_init() failed with rc=-1
[2025-07-18T15:06:29.684] error: Failed to invoke spank plugin stack
srun: error: gpu-1-0: task 0: Exited with exit code 1
command terminated with exit code 1
```

**After fix:**

```bash
srun --container-image=pytorch.sqsh --gres=gpu:4 \
  python3 -c "import torch; print('CUDA available:', torch.cuda.is_available()); print('Device count:', torch.cuda.device_count()); print('Device 0:', torch.cuda.get_device_name(0))"

CUDA available: True
Device count: 4
Device 0: NVIDIA H100 80GB HBM3
```

thanks Pallab Bhattacharya (@pallab-zz) for the root cause identification and help with the solution