### PR TITLE
Add multi-architecture support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,4 @@
 ---
-
 workflow:
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
@@ -18,6 +17,9 @@ default:
     - docker:28.1-dind
   before_script:
     - docker info
+    - docker buildx create --use --name multiarch-builder || true
+    - docker buildx use multiarch-builder
+    - docker buildx inspect --bootstrap
     - echo "$CI_REGISTRY_PASSWORD" | docker login $CI_REGISTRY -u $CI_REGISTRY_USER --password-stdin
 
 variables:
@@ -54,6 +56,9 @@ variables:
           - ubuntu24.04
   before_script:
     - docker info
+    - docker buildx create --use --name multiarch-builder || true
+    - docker buildx use multiarch-builder
+    - docker buildx inspect --bootstrap
     - echo "$CI_REGISTRY_PASSWORD" | docker login $CI_REGISTRY -u $CI_REGISTRY_USER --password-stdin
     - |
       if [ -z $DOCKER_REGISTRY_PASSWORD ] || [ -z $DOCKER_REGISTRY ] || [ -z $DOCKER_REGISTRY_USER ]; then

--- a/schedmd/slurm/24.05/docker-bake.hcl
+++ b/schedmd/slurm/24.05/docker-bake.hcl
@@ -33,6 +33,7 @@ function "format_tag" {
 ################################################################################
 
 target "_slurm" {
+  platforms = ["linux/amd64", "linux/arm64"]
   labels = {
     # Ref: https://github.com/opencontainers/image-spec/blob/v1.0/annotations.md
     "org.opencontainers.image.authors" = "slinky@schedmd.com"

--- a/schedmd/slurm/24.11/docker-bake.hcl
+++ b/schedmd/slurm/24.11/docker-bake.hcl
@@ -33,6 +33,7 @@ function "format_tag" {
 ################################################################################
 
 target "_slurm" {
+  platforms = ["linux/amd64", "linux/arm64"]
   labels = {
     # Ref: https://github.com/opencontainers/image-spec/blob/v1.0/annotations.md
     "org.opencontainers.image.authors" = "slinky@schedmd.com"

--- a/schedmd/slurm/24.11/rockylinux9/Dockerfile.pyxis
+++ b/schedmd/slurm/24.11/rockylinux9/Dockerfile.pyxis
@@ -8,18 +8,35 @@ ARG ENROOT_VERSION=3.5.0
 ARG PYXIS_VERSION=0.20.0
 
 ################################################################################
-FROM ghcr.io/slinkyproject/slurmd:24.11-rockylinux9 AS download
+FROM --platform=$BUILDPLATFORM ghcr.io/slinkyproject/slurmd:24.11-rockylinux9 AS download
 
 SHELL ["bash", "-c"]
 
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 USER root
 WORKDIR /tmp/
 
 ARG ENROOT_VERSION
 ENV ENROOT_VERSION="${ENROOT_VERSION}"
 
-ADD https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot-${ENROOT_VERSION}-1.el8.x86_64.rpm enroot-${ENROOT_VERSION}-1.el8.x86_64.rpm
-ADD https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps-${ENROOT_VERSION}-1.el8.x86_64.rpm enroot+caps-${ENROOT_VERSION}-1.el8.x86_64.rpm
+# Set architecture for package downloads
+ARG TARGETARCH
+ARG RPM_ARCH=${TARGETARCH:-amd64}
+
+RUN <<EOR
+#!/bin/bash
+set -euo pipefail
+case ${TARGETARCH:-amd64} in
+  amd64) ARCH="x86_64" ;;
+  arm64) ARCH="aarch64" ;;
+  *) ARCH="x86_64" ;;
+esac
+curl -L -o enroot-${ENROOT_VERSION}-1.el8.${ARCH}.rpm \
+  https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot-${ENROOT_VERSION}-1.el8.${ARCH}.rpm
+curl -L -o enroot+caps-${ENROOT_VERSION}-1.el8.${ARCH}.rpm \
+  https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps-${ENROOT_VERSION}-1.el8.${ARCH}.rpm
+EOR
 
 ARG PYXIS_VERSION
 ENV PYXIS_VERSION="${PYXIS_VERSION}"
@@ -31,6 +48,7 @@ ADD https://github.com/NVIDIA/pyxis/archive/refs/tags/v${PYXIS_VERSION}.tar.gz p
 RUN <<EOR
 # Generate Pyxis RPM
 set -xeuo pipefail
+echo "Building on $BUILDPLATFORM for $TARGETPLATFORM"
 dnf -q -y update
 dnf -q -y install --setopt='install_weak_deps=False' \
   '@Development' \

--- a/schedmd/slurm/24.11/ubuntu24.04/Dockerfile.pyxis
+++ b/schedmd/slurm/24.11/ubuntu24.04/Dockerfile.pyxis
@@ -8,11 +8,13 @@ ARG ENROOT_VERSION=3.5.0
 ARG PYXIS_VERSION=0.20.0
 
 ################################################################################
-FROM ghcr.io/slinkyproject/slurmd:24.11-ubuntu24.04 AS download
+FROM --platform=$BUILDPLATFORM ghcr.io/slinkyproject/slurmd:24.11-ubuntu24.04 AS download
 
 SHELL ["bash", "-c"]
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
 USER root
 WORKDIR /tmp/
@@ -20,8 +22,12 @@ WORKDIR /tmp/
 ARG ENROOT_VERSION
 ENV ENROOT_VERSION="${ENROOT_VERSION}"
 
-ADD https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot_${ENROOT_VERSION}-1_amd64.deb enroot_${ENROOT_VERSION}-1_amd64.deb
-ADD https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps_${ENROOT_VERSION}-1_amd64.deb enroot+caps_${ENROOT_VERSION}-1_amd64.deb
+# Set architecture for package downloads
+ARG TARGETARCH
+ARG DEB_ARCH=${TARGETARCH:-amd64}
+
+ADD https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot_${ENROOT_VERSION}-1_${DEB_ARCH}.deb enroot_${ENROOT_VERSION}-1_${DEB_ARCH}.deb
+ADD https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps_${ENROOT_VERSION}-1_${DEB_ARCH}.deb enroot+caps_${ENROOT_VERSION}-1_${DEB_ARCH}.deb
 
 ARG PYXIS_VERSION
 ENV PYXIS_VERSION="${PYXIS_VERSION}"
@@ -33,6 +39,7 @@ ADD https://github.com/NVIDIA/pyxis/archive/refs/tags/v${PYXIS_VERSION}.tar.gz p
 RUN <<EOR
 # Generate Pyxis DEB
 set -xeuo pipefail
+echo "Building on $BUILDPLATFORM for $TARGETPLATFORM"
 apt-get -qq update
 apt-get -qq -y install --no-install-recommends \
   build-essential \

--- a/schedmd/slurm/25.05/docker-bake.hcl
+++ b/schedmd/slurm/25.05/docker-bake.hcl
@@ -33,6 +33,7 @@ function "format_tag" {
 ################################################################################
 
 target "_slurm" {
+  platforms = ["linux/amd64", "linux/arm64"]
   labels = {
     # Ref: https://github.com/opencontainers/image-spec/blob/v1.0/annotations.md
     "org.opencontainers.image.authors" = "slinky@schedmd.com"

--- a/schedmd/slurm/25.05/rockylinux9/Dockerfile.pyxis
+++ b/schedmd/slurm/25.05/rockylinux9/Dockerfile.pyxis
@@ -8,18 +8,35 @@ ARG ENROOT_VERSION=3.5.0
 ARG PYXIS_VERSION=0.20.0
 
 ################################################################################
-FROM ghcr.io/slinkyproject/slurmd:25.05-rockylinux9 AS download
+FROM --platform=$BUILDPLATFORM ghcr.io/slinkyproject/slurmd:25.05-rockylinux9 AS download
 
 SHELL ["bash", "-c"]
 
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 USER root
 WORKDIR /tmp/
 
 ARG ENROOT_VERSION
 ENV ENROOT_VERSION="${ENROOT_VERSION}"
 
-ADD https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot-${ENROOT_VERSION}-1.el8.x86_64.rpm enroot-${ENROOT_VERSION}-1.el8.x86_64.rpm
-ADD https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps-${ENROOT_VERSION}-1.el8.x86_64.rpm enroot+caps-${ENROOT_VERSION}-1.el8.x86_64.rpm
+# Set architecture for package downloads
+ARG TARGETARCH
+
+# Use RUN to download packages with architecture detection
+RUN <<EOR
+#!/bin/bash
+set -euo pipefail
+case ${TARGETARCH:-amd64} in
+  amd64) ARCH="x86_64" ;;
+  arm64) ARCH="aarch64" ;;
+  *) ARCH="x86_64" ;;
+esac
+curl -L -o enroot-${ENROOT_VERSION}-1.el8.${ARCH}.rpm \
+  https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot-${ENROOT_VERSION}-1.el8.${ARCH}.rpm
+curl -L -o enroot+caps-${ENROOT_VERSION}-1.el8.${ARCH}.rpm \
+  https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps-${ENROOT_VERSION}-1.el8.${ARCH}.rpm
+EOR
 
 ARG PYXIS_VERSION
 ENV PYXIS_VERSION="${PYXIS_VERSION}"
@@ -31,6 +48,7 @@ ADD https://github.com/NVIDIA/pyxis/archive/refs/tags/v${PYXIS_VERSION}.tar.gz p
 RUN <<EOR
 # Generate Pyxis RPM
 set -xeuo pipefail
+echo "Building on $BUILDPLATFORM for $TARGETPLATFORM"
 dnf -q -y update
 dnf -q -y install --setopt='install_weak_deps=False' \
   '@Development' \

--- a/schedmd/slurm/25.05/ubuntu24.04/Dockerfile
+++ b/schedmd/slurm/25.05/ubuntu24.04/Dockerfile
@@ -4,7 +4,7 @@
 
 ################################################################################
 
-ARG SLURM_VERSION=25.05-latest
+ARG SLURM_VERSION=25.05.2
 ARG SLURM_DIR="slurm-${SLURM_VERSION}"
 ARG PARENT_IMAGE=ubuntu:24.04
 

--- a/schedmd/slurm/25.05/ubuntu24.04/Dockerfile.pyxis
+++ b/schedmd/slurm/25.05/ubuntu24.04/Dockerfile.pyxis
@@ -8,11 +8,13 @@ ARG ENROOT_VERSION=3.5.0
 ARG PYXIS_VERSION=0.20.0
 
 ################################################################################
-FROM ghcr.io/slinkyproject/slurmd:25.05-ubuntu24.04 AS download
+FROM --platform=$BUILDPLATFORM ghcr.io/slinkyproject/slurmd:25.05-ubuntu24.04 AS download
 
 SHELL ["bash", "-c"]
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
 USER root
 WORKDIR /tmp/
@@ -20,8 +22,12 @@ WORKDIR /tmp/
 ARG ENROOT_VERSION
 ENV ENROOT_VERSION="${ENROOT_VERSION}"
 
-ADD https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot_${ENROOT_VERSION}-1_amd64.deb enroot_${ENROOT_VERSION}-1_amd64.deb
-ADD https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps_${ENROOT_VERSION}-1_amd64.deb enroot+caps_${ENROOT_VERSION}-1_amd64.deb
+# Set architecture for package downloads
+ARG TARGETARCH
+ARG DEB_ARCH=${TARGETARCH:-amd64}
+
+ADD https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot_${ENROOT_VERSION}-1_${DEB_ARCH}.deb enroot_${ENROOT_VERSION}-1_${DEB_ARCH}.deb
+ADD https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps_${ENROOT_VERSION}-1_${DEB_ARCH}.deb enroot+caps_${ENROOT_VERSION}-1_${DEB_ARCH}.deb
 
 ARG PYXIS_VERSION
 ENV PYXIS_VERSION="${PYXIS_VERSION}"
@@ -33,6 +39,7 @@ ADD https://github.com/NVIDIA/pyxis/archive/refs/tags/v${PYXIS_VERSION}.tar.gz p
 RUN <<EOR
 # Generate Pyxis DEB
 set -xeuo pipefail
+echo "Building on $BUILDPLATFORM for $TARGETPLATFORM"
 apt-get -qq update
 apt-get -qq -y install --no-install-recommends \
   build-essential \

--- a/schedmd/slurm/README.md
+++ b/schedmd/slurm/README.md
@@ -12,6 +12,18 @@ docker buildx bake
 docker buildx bake --push
 ```
 
+## Multi-Architecture
+
+Images support both `linux/amd64` and `linux/arm64` platforms:
+
+```bash
+# Multi-arch build
+docker buildx bake --set "*.platform=linux/amd64,linux/arm64" ubuntu2404-core
+
+# ARM64 only build
+docker buildx bake --set "*.platform=linux/arm64" --push ubuntu2404-core
+```
+
 <!-- Links -->
 
 [schedmd]: https://www.schedmd.com/

--- a/schedmd/slurm/master/docker-bake.hcl
+++ b/schedmd/slurm/master/docker-bake.hcl
@@ -33,6 +33,7 @@ function "format_tag" {
 ################################################################################
 
 target "_slurm" {
+  platforms = ["linux/amd64", "linux/arm64"]
   labels = {
     # Ref: https://github.com/opencontainers/image-spec/blob/v1.0/annotations.md
     "org.opencontainers.image.authors" = "slinky@schedmd.com"

--- a/schedmd/slurm/master/rockylinux9/Dockerfile.pyxis
+++ b/schedmd/slurm/master/rockylinux9/Dockerfile.pyxis
@@ -8,18 +8,35 @@ ARG ENROOT_VERSION=3.5.0
 ARG PYXIS_VERSION=0.20.0
 
 ################################################################################
-FROM ghcr.io/slinkyproject/slurmd:master-rockylinux9 AS download
+FROM --platform=$BUILDPLATFORM ghcr.io/slinkyproject/slurmd:master-rockylinux9 AS download
 
 SHELL ["bash", "-c"]
 
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 USER root
 WORKDIR /tmp/
 
 ARG ENROOT_VERSION
 ENV ENROOT_VERSION="${ENROOT_VERSION}"
 
-ADD https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot-${ENROOT_VERSION}-1.el8.x86_64.rpm enroot-${ENROOT_VERSION}-1.el8.x86_64.rpm
-ADD https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps-${ENROOT_VERSION}-1.el8.x86_64.rpm enroot+caps-${ENROOT_VERSION}-1.el8.x86_64.rpm
+# Set architecture for package downloads
+ARG TARGETARCH
+ARG RPM_ARCH=${TARGETARCH:-amd64}
+
+RUN <<EOR
+#!/bin/bash
+set -euo pipefail
+case ${TARGETARCH:-amd64} in
+  amd64) ARCH="x86_64" ;;
+  arm64) ARCH="aarch64" ;;
+  *) ARCH="x86_64" ;;
+esac
+curl -L -o enroot-${ENROOT_VERSION}-1.el8.${ARCH}.rpm \
+  https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot-${ENROOT_VERSION}-1.el8.${ARCH}.rpm
+curl -L -o enroot+caps-${ENROOT_VERSION}-1.el8.${ARCH}.rpm \
+  https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps-${ENROOT_VERSION}-1.el8.${ARCH}.rpm
+EOR
 
 ARG PYXIS_VERSION
 ENV PYXIS_VERSION="${PYXIS_VERSION}"
@@ -31,6 +48,7 @@ ADD https://github.com/NVIDIA/pyxis/archive/refs/tags/v${PYXIS_VERSION}.tar.gz p
 RUN <<EOR
 # Generate Pyxis RPM
 set -xeuo pipefail
+echo "Building on $BUILDPLATFORM for $TARGETPLATFORM"
 dnf -q -y update
 dnf -q -y install --setopt='install_weak_deps=False' \
   '@Development' \

--- a/schedmd/slurm/master/ubuntu24.04/Dockerfile.pyxis
+++ b/schedmd/slurm/master/ubuntu24.04/Dockerfile.pyxis
@@ -8,11 +8,13 @@ ARG ENROOT_VERSION=3.5.0
 ARG PYXIS_VERSION=0.20.0
 
 ################################################################################
-FROM ghcr.io/slinkyproject/slurmd:master-ubuntu24.04 AS download
+FROM --platform=$BUILDPLATFORM ghcr.io/slinkyproject/slurmd:master-ubuntu24.04 AS download
 
 SHELL ["bash", "-c"]
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
 USER root
 WORKDIR /tmp/
@@ -20,8 +22,12 @@ WORKDIR /tmp/
 ARG ENROOT_VERSION
 ENV ENROOT_VERSION="${ENROOT_VERSION}"
 
-ADD https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot_${ENROOT_VERSION}-1_amd64.deb enroot_${ENROOT_VERSION}-1_amd64.deb
-ADD https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps_${ENROOT_VERSION}-1_amd64.deb enroot+caps_${ENROOT_VERSION}-1_amd64.deb
+# Set architecture for package downloads
+ARG TARGETARCH
+ARG DEB_ARCH=${TARGETARCH:-amd64}
+
+ADD https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot_${ENROOT_VERSION}-1_${DEB_ARCH}.deb enroot_${ENROOT_VERSION}-1_${DEB_ARCH}.deb
+ADD https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps_${ENROOT_VERSION}-1_${DEB_ARCH}.deb enroot+caps_${ENROOT_VERSION}-1_${DEB_ARCH}.deb
 
 ARG PYXIS_VERSION
 ENV PYXIS_VERSION="${PYXIS_VERSION}"
@@ -33,6 +39,7 @@ ADD https://github.com/NVIDIA/pyxis/archive/refs/tags/v${PYXIS_VERSION}.tar.gz p
 RUN <<EOR
 # Generate Pyxis DEB
 set -xeuo pipefail
+echo "Building on $BUILDPLATFORM for $TARGETPLATFORM"
 apt-get -qq update
 apt-get -qq -y install --no-install-recommends \
   build-essential \


### PR DESCRIPTION
This PR enables building Docker images for both linux/amd64 and linux/arm64 platforms.

## Changes

- Updated all docker-bake.hcl files to include platforms = ["linux/amd64", "linux/arm64"]
- Modified GitLab CI to use Docker Buildx for multi-arch builds
- Ubuntu: Added dynamic architecture detection using ARG TARGETARCH for Enroot/Pyxis package downloads
- Rocky Linux: Implemented architecture mapping (amd64 → x86_64, arm64 → aarch64) with curl downloads

## Notes/Questions:

Core Slurm images are inherently multi-arch compatible (built from source). I managed to build and run these in ARM based systems.
