### PR TITLE
Mount tmpfs in entrypoint of pyxis images

### DIFF
--- a/schedmd/slurm/24.11/ubuntu24.04/Dockerfile.pyxis
+++ b/schedmd/slurm/24.11/ubuntu24.04/Dockerfile.pyxis
@@ -88,6 +88,7 @@ mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
 # Fix NVIDIA proc mount for GPUs
 sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
+sed -i '2i mount -t tmpfs tmpfs /tmp 2>/dev/null || true' /usr/local/bin/entrypoint.sh
 EOR
 
 ADD https://nvidia.github.io/libnvidia-container/gpgkey libnvidia-container.gpgkey
@@ -137,6 +138,7 @@ mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
 # Fix NVIDIA proc mount for GPUs
 sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
+sed -i '2i mount -t tmpfs tmpfs /tmp 2>/dev/null || true' /usr/local/bin/entrypoint.sh
 EOR
 
 ADD https://nvidia.github.io/libnvidia-container/gpgkey libnvidia-container.gpgkey

--- a/schedmd/slurm/25.05/rockylinux9/Dockerfile.pyxis
+++ b/schedmd/slurm/25.05/rockylinux9/Dockerfile.pyxis
@@ -90,6 +90,7 @@ mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
 # Fix NVIDIA proc mount for GPUs
 sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
+sed -i '2i mount -t tmpfs tmpfs /tmp 2>/dev/null || true' /usr/local/bin/entrypoint.sh
 EOR
 
 ADD https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo /etc/yum.repos.d/nvidia-container-toolkit.repo
@@ -140,6 +141,7 @@ mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
 # Fix NVIDIA proc mount for GPUs
 sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
+sed -i '2i mount -t tmpfs tmpfs /tmp 2>/dev/null || true' /usr/local/bin/entrypoint.sh
 EOR
 
 ADD https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo /etc/yum.repos.d/nvidia-container-toolkit.repo

--- a/schedmd/slurm/25.05/ubuntu24.04/Dockerfile.pyxis
+++ b/schedmd/slurm/25.05/ubuntu24.04/Dockerfile.pyxis
@@ -88,6 +88,7 @@ mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
 # Fix NVIDIA proc mount for GPUs
 sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
+sed -i '2i mount -t tmpfs tmpfs /tmp 2>/dev/null || true' /usr/local/bin/entrypoint.sh
 EOR
 
 ADD https://nvidia.github.io/libnvidia-container/gpgkey libnvidia-container.gpgkey
@@ -137,6 +138,7 @@ mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
 # Fix NVIDIA proc mount for GPUs
 sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
+sed -i '2i mount -t tmpfs tmpfs /tmp 2>/dev/null || true' /usr/local/bin/entrypoint.sh
 EOR
 
 ADD https://nvidia.github.io/libnvidia-container/gpgkey libnvidia-container.gpgkey

--- a/schedmd/slurm/master/rockylinux9/Dockerfile.pyxis
+++ b/schedmd/slurm/master/rockylinux9/Dockerfile.pyxis
@@ -90,6 +90,7 @@ mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
 # Fix NVIDIA proc mount for GPUs
 sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
+sed -i '2i mount -t tmpfs tmpfs /tmp 2>/dev/null || true' /usr/local/bin/entrypoint.sh
 EOR
 
 ADD https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo /etc/yum.repos.d/nvidia-container-toolkit.repo
@@ -140,6 +141,7 @@ mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
 # Fix NVIDIA proc mount for GPUs
 sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
+sed -i '2i mount -t tmpfs tmpfs /tmp 2>/dev/null || true' /usr/local/bin/entrypoint.sh
 EOR
 
 ADD https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo /etc/yum.repos.d/nvidia-container-toolkit.repo

--- a/schedmd/slurm/master/ubuntu24.04/Dockerfile.pyxis
+++ b/schedmd/slurm/master/ubuntu24.04/Dockerfile.pyxis
@@ -88,6 +88,7 @@ mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
 # Fix NVIDIA proc mount for GPUs
 sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
+sed -i '2i mount -t tmpfs tmpfs /tmp 2>/dev/null || true' /usr/local/bin/entrypoint.sh
 EOR
 
 ADD https://nvidia.github.io/libnvidia-container/gpgkey libnvidia-container.gpgkey
@@ -137,6 +138,7 @@ mkdir -m 644 -p /etc/slurm/plugstack.conf.d/
 ln -s /usr/share/pyxis/pyxis.conf /etc/slurm/plugstack.conf.d/pyxis.conf
 # Fix NVIDIA proc mount for GPUs
 sed -i '2i mount -t proc none /proc 2>/dev/null || true' /usr/local/bin/entrypoint.sh
+sed -i '2i mount -t tmpfs tmpfs /tmp 2>/dev/null || true' /usr/local/bin/entrypoint.sh
 EOR
 
 ADD https://nvidia.github.io/libnvidia-container/gpgkey libnvidia-container.gpgkey


### PR DESCRIPTION
Fixes https://github.com/SlinkyProject/slurm-operator/issues/42

Mounts tmpfs to /tmp in slurmd and login pyxis images to overcome enroot overlayfs Operation not permitted caused by complex multi-layer images>

Tested with: nvcr.io/nvidia/pytorch:25.04-py3