### PR TITLE
Modify loginsets image to support IPA/IdM+external IdP auth

### DIFF
--- a/schedmd/slurm/25.11/rockylinux9/Dockerfile
+++ b/schedmd/slurm/25.11/rockylinux9/Dockerfile
@@ -325,12 +325,16 @@ set -xeuo pipefail
 dnf -q -y install --setopt='install_weak_deps=False' \
   socat \
   openssh-server \
-  authselect sssd sssd-ad sssd-ldap
+  authselect sssd sssd-ad sssd-ipa sssd-krb5 sssd-ldap sssd-idp \
+  krb5-pkinit
 # Configure
 mkdir -p /etc/authselect
 authselect select sssd with-mkhomedir --force
 rm -f /etc/ssh/ssh_host_*
 EOR
+
+# Override sshd config to enable keyboard-interactive for OAuth2/IdP auth
+RUN echo "KbdInteractiveAuthentication yes" > /etc/ssh/sshd_config.d/00-ipa-idp.conf
 
 COPY files/etc/supervisord.conf /etc/
 COPY \


### PR DESCRIPTION
… FreeIPA/IdM setups

Added additional SSSD components and configured SSH for OAuth2/IdP authentication.

<!--
Feature requests, code contributions, and bug reports are welcome!
Github/Gitlab submitted issues and PRs/MRs are handled on a best effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary

For setups that has identity managers like FreeIPA/IdM, the current flow supports bare-bone sssd that works with LDAP and doesn't allow for any sophisticated access control or login flows like external IdPs, etc.

Added packages are: `sssd-ipa`, `sssd-idp`, `sssd-krb5` and `krb5-pkinit`. Lastly a sshd-conf.d rule that enables keyboard-interactive for OAuth2/IdP auth.

## Breaking Changes

N/A

## Testing Notes

Verified with proper sssd.conf file, extra mounts like IPA's ca.crt and a valid host keytab the following:
- id <ipa_user>, read valid uid/gid(s)
- getent passwd <ipa_user>, yielded valid results
- SSH login now presents the device code URL instead of a password prompt for IdP-auth enabled users
- Non-IdP users (password/OTP auth) are unaffected
- Validated HBAC rules managed by IPA/IdM that targeted the keytab's hostname successfully i.e. you can manage access control for the loginsets, this is useful in hybrid clusters.

## Additional Context

This is a sample configuration for sssd.conf with IPA
```yaml
[sssd]
    config_file_version = 2
    services = nss, pam, ssh, sudo
    domains = hpc.naitive.ai

    [nss]
    homedir_substring = /home

    [pam]

    [sudo]

    [ssh]

    [domain/<DOMAIN>]
    id_provider = ipa
    auth_provider = ipa
    chpass_provider = ipa
    access_provider = ipa

    selinux_provider = none

    ipa_domain = <DOMAIN>
    ipa_hostname = slinky-login.<DOMAIN>
    ipa_server = ipa01.<DOMAIN>
    ipa_backup_server = ipa02.<DOMAIN>

    # Mounted ca.crt via configmap
    ldap_tls_cacert = /etc/ca.crt

    krb5_use_fast = try
    krb5_fast_principal = sssd/slinky-login.<DOMAIN>@<REALM>
    # Mounted keytab via secrets
    krb5_keytab = /etc/krb5.keytab

    krb5_validate = false
    krb5_store_password_if_offline = true
    cache_credentials = true
    enumerate = true
```
