### PR TITLE
feat: add postfix to slurmctld and login images

### DIFF
--- a/schedmd/slurm/25.11/rockylinux9/Dockerfile
+++ b/schedmd/slurm/25.11/rockylinux9/Dockerfile
@@ -156,6 +156,7 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked <<EOR
 set -xeuo pipefail
 dnf -q -y install --setopt='install_weak_deps=False' \
   socat \
+  postfix \
   ./slurm-slurmctld-[0-9]*.rpm \
   ./slurm-[0-9]*.rpm
 rm *.rpm
@@ -165,6 +166,7 @@ COPY files/etc/supervisord.conf /etc/
 COPY \
   files/etc/supervisord.d/slurmctld.ini \
   files/etc/supervisord.d/fakesystemd.ini \
+  files/etc/supervisord.d/postfix.ini \
   /etc/supervisord.d/
 COPY files/usr/local/bin/fakesystemd.sh /usr/local/bin/
 COPY files/usr/local/bin/slurmctld-entrypoint.sh /usr/local/bin/entrypoint.sh
@@ -326,6 +328,7 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked <<EOR
 set -xeuo pipefail
 dnf -q -y install --setopt='install_weak_deps=False' \
   socat \
+  postfix \
   openssh-server \
   authselect sssd sssd-ad sssd-ldap
 # Configure
@@ -340,6 +343,7 @@ COPY \
   files/etc/supervisord.d/sackd.ini \
   files/etc/supervisord.d/sshd.ini \
   files/etc/supervisord.d/sssd.ini \
+  files/etc/supervisord.d/postfix.ini \
   /etc/supervisord.d/
 COPY files/usr/local/bin/fakesystemd.sh /usr/local/bin/
 COPY files/usr/local/bin/login-entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/schedmd/slurm/25.11/rockylinux9/files/etc/supervisord.d/postfix.ini
+++ b/schedmd/slurm/25.11/rockylinux9/files/etc/supervisord.d/postfix.ini
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+# SPDX-License-Identifier: Apache-2.0
+
+[program:postfix]
+command=bash -xc "postfix check && exec /usr/sbin/postfix start-fg %(ENV_POSTFIX_OPTIONS)s"
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
+stopasgroup=true

--- a/schedmd/slurm/25.11/ubuntu24.04/Dockerfile
+++ b/schedmd/slurm/25.11/ubuntu24.04/Dockerfile
@@ -145,6 +145,7 @@ set -xeuo pipefail
 apt-get -qq update
 apt-get -qq -y install --no-install-recommends --fix-broken \
   socat \
+  postfix \
   ./slurm-smd-client_[0-9]*.deb \
   ./slurm-smd-client-dbgsym_[0-9]*.ddeb \
   ./slurm-smd-dev_[0-9]*.deb \
@@ -160,6 +161,7 @@ COPY files/etc/supervisor/supervisord.conf /etc/supervisor/
 COPY \
   files/etc/supervisor/conf.d/slurmctld.conf \
   files/etc/supervisor/conf.d/fakesystemd.conf \
+  files/etc/supervisor/conf.d/postfix.conf \
   /etc/supervisor/conf.d/
 COPY files/usr/local/bin/fakesystemd.sh /usr/local/bin/
 COPY files/usr/local/bin/slurmctld-entrypoint.sh /usr/local/bin/entrypoint.sh
@@ -361,6 +363,7 @@ set -xeuo pipefail
 apt-get -qq update
 apt-get -qq -y install --no-install-recommends \
   socat \
+  postfix \
   openssh-server \
   authselect sssd sssd-ad sssd-ldap libpam-sss libnss-sss
 # Configure
@@ -375,6 +378,7 @@ COPY \
   files/etc/supervisor/conf.d/sackd.conf \
   files/etc/supervisor/conf.d/sshd.conf \
   files/etc/supervisor/conf.d/sssd.conf \
+  files/etc/supervisor/conf.d/postfix.conf \
   /etc/supervisor/conf.d/
 COPY files/usr/local/bin/fakesystemd.sh /usr/local/bin/
 COPY files/usr/local/bin/login-entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/schedmd/slurm/25.11/ubuntu24.04/files/etc/supervisor/conf.d/postfix.conf
+++ b/schedmd/slurm/25.11/ubuntu24.04/files/etc/supervisor/conf.d/postfix.conf
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+# SPDX-License-Identifier: Apache-2.0
+
+[program:postfix]
+command=bash -xc "postfix check && exec /usr/sbin/postfix start-fg %(ENV_POSTFIX_OPTIONS)s"
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
+stopasgroup=true


### PR DESCRIPTION
## Summary

- Install `postfix` and run it under supervisord in the `slurmctld` and `login` stages.
- Applied to both `25.11/ubuntu24.04` and `25.11/rockylinux9` images.
- Adds supervisor program configs: `postfix.conf` (Ubuntu) and `postfix.ini` (Rocky), running the master daemon in the foreground via `postfix start-fg` so supervisord can manage it.

This provides a local MTA so Slurm mail notifications work, e.g.:

```bash
sbatch \
  --mail-type=BEGIN,END,FAIL \
  --mail-user=me@example.com \
  --wrap='hostname'
```

With postfix present, Slurm's `MailProg` (sendmail/mail) can deliver these notifications.

## Test plan

- [ ] Build `slurmctld` and `login` targets for both distros.
- [ ] Confirm `postfix` is installed and the supervisord `postfix` program starts (`supervisorctl status postfix`).
- [ ] Submit a job with `--mail-type`/`--mail-user` and verify a notification mail is generated.